### PR TITLE
Fix sampler conflict with #30033 for depthTexture in WGSLNodeBuilder.js

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -400,6 +400,12 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 	}
 
+	isSampleCompare( texture ) {
+
+		return texture.isDepthTexture === true && texture.compareFunction !== null;
+
+	}
+
 	isUnfilterable( texture ) {
 
 		return this.getComponentTypeFromTexture( texture ) !== 'float' ||

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -73,28 +73,7 @@ const wgslTypeLib = {
 
 	mat2: 'mat2x2<f32>',
 	mat3: 'mat3x3<f32>',
-	mat4: 'mat4x4<f32>',
-
-	//because arrays with their two degrees of freedom are special
-	array( elementType, count ) {
-
-		const isValidType = ( type ) => !! this[ type ];
-
-		if ( ! isValidType( elementType ) ) {
-
-			throw new Error( `Unknown type: ${elementType}` );
-
-		}
-
-		if ( typeof count !== 'number' || ! Number.isInteger( count ) || count < 1 ) {
-
-			throw new Error( `Invalid size: ${count}. Size must be a positive integer` );
-
-		}
-
-		return `array<${this[ elementType ]}, ${count}>`;
-
-	}
+	mat4: 'mat4x4<f32>'
 };
 
 const wgslCodeCache = {};

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -400,17 +400,10 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 	}
 
-	isSampleCompare( texture ) {
-
-		return texture.isDepthTexture === true && texture.compareFunction !== null;
-
-	}
-
 	isUnfilterable( texture ) {
 
 		return this.getComponentTypeFromTexture( texture ) !== 'float' ||
 			( ! this.isAvailable( 'float32Filterable' ) && texture.isDataTexture === true && texture.type === FloatType ) ||
-			( this.isSampleCompare( texture ) === false && texture.minFilter === NearestFilter && texture.magFilter === NearestFilter ) ||
 			this.renderer.backend.utils.getTextureSampleData( texture ).primarySamples > 1;
 
 	}

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -16,7 +16,7 @@ import { NodeAccess } from '../../../nodes/core/constants.js';
 import VarNode from '../../../nodes/core/VarNode.js';
 import ExpressionNode from '../../../nodes/code/ExpressionNode.js';
 
-import { NoColorSpace, FloatType, RepeatWrapping, ClampToEdgeWrapping, MirroredRepeatWrapping, NearestFilter } from '../../../constants.js';
+import { NoColorSpace, FloatType, RepeatWrapping, ClampToEdgeWrapping, MirroredRepeatWrapping } from '../../../constants.js';
 
 // GPUShaderStage is not defined in browsers not supporting WebGPU
 const GPUShaderStage = ( typeof self !== 'undefined' ) ? self.GPUShaderStage : { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };


### PR DESCRIPTION
The depth textures were excluded from the sampling by the compare. But depth textures are sampleable in WebGPU. But even if you don't sample, you can use the sampler for textureSampleLevel. Instead of screen coordinates like you have to use in the case of textureLoad, you can use uv coordinates with textureSampleLevel and mip 0, which is very practical.

Related issue: #30033


