### PR TITLE
Fix type annotations, modify example to showcase indirect compute

### DIFF
--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -38,7 +38,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { Fn, If, uniform, float, uv, vec2, vec3, hash, shapeCircle,
+			import { Fn, If, Switch, uniform, float, uv, vec2, vec3, hash, shapeCircle, storage,
 				instancedArray, instanceIndex } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
@@ -47,6 +47,7 @@
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			const particleCount = 200_000;
+			const movableParticleCount = particleCount / 2;
 
 			const gravity = uniform( - .00098 );
 			const bounce = uniform( .8 );
@@ -196,6 +197,24 @@
 
 				//
 
+				const movableParticleIndirectBuffer = new THREE.IndirectStorageBufferAttribute(new Uint32Array(3));
+				const movableParticleBufferNode = storage( movableParticleIndirectBuffer, 'uint' );
+
+				const computeMovableCount = Fn( () => {
+
+					If( instanceIndex.lessThan( 3 ), () => {
+						const count = movableParticleBufferNode.element(instanceIndex);
+
+						Switch(instanceIndex)
+							.Case(0, () => count.assign(Math.ceil(movableParticleCount / 64)))
+							.Case(1, () => count.assign(1))
+							.Case(2, () => count.assign(1));
+					})
+
+				} )().compute( 3 );
+
+				renderer.computeAsync( computeMovableCount );
+
 				function onMove( event ) {
 					
 					if ( isOrbitControlsActive ) return;
@@ -217,7 +236,7 @@
 
 						// compute
 
-						renderer.computeAsync( computeHit );
+						renderer.computeAsync( computeHit, movableParticleIndirectBuffer );
 
 					}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2308,10 +2308,10 @@ class Renderer {
 	 * if the renderer has been initialized.
 	 *
 	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
-	 * @param {number|Array<number>|GPUBuffer} [dispatchSize=null]
+	 * @param {number|Array<number>|IndirectStorageBufferAttribute} [dispatchSize=null]
 	 * - A single number representing count, or
 	 * - An array [x, y, z] representing dispatch size, or
-	 * - A GPUBuffer for indirect dispatch size.
+	 * - A IndirectStorageBufferAttribute for indirect dispatch size.
 	 * @return {Promise|undefined} A Promise that resolve when the compute has finished. Only returned when the renderer has not been initialized.
 	 */
 	compute( computeNodes, dispatchSize = null ) {
@@ -2410,10 +2410,10 @@ class Renderer {
 	 *
 	 * @async
 	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
-	 * @param {number|Array<number>|GPUBuffer} [dispatchSize=null]
+	 * @param {number|Array<number>|IndirectStorageBufferAttribute} [dispatchSize=null]
 	 * - A single number representing count, or
 	 * - An array [x, y, z] representing dispatch size, or
-	 * - A GPUBuffer for indirect dispatch size.
+	 * - A IndirectStorageBufferAttribute for indirect dispatch size.
 	 * @return {Promise} A Promise that resolve when the compute has finished.
 	 */
 	async computeAsync( computeNodes, dispatchSize = null ) {

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -959,6 +959,12 @@ class WebGLBackend extends Backend {
 
 			count = count[ 0 ];
 
+		} else if ( count && typeof count === 'object' && count.isIndirectStorageBufferAttribute ) {
+
+			warnOnce( 'WebGLBackend.compute(): The count parameter must be a single number, not IndirectStorageBufferAttribute' );
+
+			count = computeNode.count;
+
 		}
 
 		if ( attributes[ 0 ].isStorageInstancedBufferAttribute ) {

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1317,10 +1317,10 @@ class WebGPUBackend extends Backend {
 	 * @param {Node} computeNode - The compute node.
 	 * @param {Array<BindGroup>} bindings - The bindings.
 	 * @param {ComputePipeline} pipeline - The compute pipeline.
-	 * @param {number|Array<number>|GPUBuffer} [dispatchSize=null]
+	 * @param {number|Array<number>|IndirectStorageBufferAttribute} [dispatchSize=null]
 	 * - A single number representing count, or
 	 * - An array [x, y, z] representing dispatch size, or
-	 * - A GPUBuffer for indirect dispatch size.
+	 * - A IndirectStorageBufferAttribute for indirect dispatch size.
 	 */
 	compute( computeGroup, computeNode, bindings, pipeline, dispatchSize = null ) {
 


### PR DESCRIPTION
Hi @Spiri0!
I wanted to help you out a bit with the PR for computeIndirect: https://github.com/mrdoob/three.js/pull/31488
- Fixed type annotations for methods
- Handle IndirectStorageBufferAttribute in webgl fallback backend
- Modify webgpu_compute_particles example to use indirect dispatch

Example thing maybe weird - couldn't come up with a better easy way to demonstrate usefulness of the feature. Maybe there should be a separate example altogether?
